### PR TITLE
Fix: run.cmd start script from correct path

### DIFF
--- a/run.cmd
+++ b/run.cmd
@@ -5,5 +5,7 @@ whoami /user | find /i "S-1-5-18" > nul 2>&1 || (
 	exit /b
 )
 
+SET mypath=%~dp0
+cd %mypath%
 powershell.exe -Command "& {python src/main.py %*}"
 pause


### PR DESCRIPTION
Using the run.cmd currently cannot launch main.py as RunAsTI runs the commands to start the script from the System32 folder. This updated script ensures this the script runs the commands to start the script from the executing path.